### PR TITLE
Fixed a little spelling error

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -56,7 +56,7 @@ msgstr "Temperatura:"
 
 #: applet.js:492
 msgid "Humidity:"
-msgstr "Humidade"
+msgstr "Umidade"
 
 #: applet.js:494
 msgid "Pressure:"


### PR DESCRIPTION
The portuguese for "Humidity" is "Umidade", not "Humidade".
