### PR TITLE
don't break Cinnamon's localization by setting an own gettext standard domain

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -36,7 +36,6 @@ const Applet = imports.ui.applet;
 const Cairo = imports.cairo;
 const ExtensionSystem = imports.ui.extensionSystem;
 const Gettext = imports.gettext;
-const _ = Gettext.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
@@ -145,8 +144,11 @@ function getSettings(schema) {
 //
 //----------------------------------------------------------------------
 
-Gettext.textdomain(UUID);
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() +"/.local/share/locale");
+
+function _(str) {
+  return Gettext.dgettext(UUID, str);
+}
 
 //----------------------------------------------------------------------
 //


### PR DESCRIPTION
By calling Gettext.textdomain(), a new standard domain is set and breaks cinnamon's own localization for anything loaded afterwards.

This fix avoids setting a new standard domain and instead uses an own function named _(), wrapping Gettext.dgettext(). The new _() is only valid inside this file.
