### PR TITLE
Normalize minutes display in sunrise/sunset times

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -407,6 +407,10 @@ MyApplet.prototype = {
 
         let sunrise = weather.get_object_member('astronomy').get_string_member('sunrise')
         let sunset = weather.get_object_member('astronomy').get_string_member('sunset')
+        //log('sunrise: ' + sunrise)
+        //log('sunset: ' + sunset)
+        sunrise = this.normalizeMinutes(sunrise)
+        sunset = this.normalizeMinutes(sunset)
 
         let temperature = weather_c.get_string_member('temp')
 
@@ -583,6 +587,22 @@ MyApplet.prototype = {
         this.refreshWeather(true)
       }))
     }
+  }
+
+, normalizeMinutes: function normalizeMinutes(timeStr) {
+    // verify expected time format
+    let result = timeStr.match(/^\d{1,2}:(\d{1,2}) [ap]m$/)
+
+    if (result != null) {
+      let minutes = result[1]
+      // single-digit minutes values need normalizing (zero-padding)
+      if (minutes.length < 2) {
+        let timeSegments = timeStr.split(':')
+        return timeSegments[0] + ':0' + timeSegments[1]
+      }
+    }
+
+    return timeStr
   }
 
 , convertTo24: function convertTo24(timeStr) {


### PR DESCRIPTION
This pull request addresses issue #150 by normalizing (zero-padding) sunrise and sunset times in which the minutes value is retrieved as a single digit.  So, for instance, a retrieved value of "6:8 am" will be reformatted to display as "6:08 am".
