### PR TITLE
Add vertical orientation display option

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -68,6 +68,7 @@ const QUERY_URL = 'http://query.yahooapis.com/v1/public/yql' + QUERY_PARAMS + QU
 const WEATHER_CITY_KEY = 'locationLabelOverride'
 const WEATHER_REFRESH_INTERVAL = 'refreshInterval'
 const WEATHER_SHOW_COMMENT_IN_PANEL_KEY = 'showCommentInPanel'
+const WEATHER_VERTICAL_ORIENTATION_KEY = 'verticalOrientation'
 const WEATHER_SHOW_SUNRISE_KEY = 'showSunrise'
 const WEATHER_SHOW_24HOURS_KEY = 'show24Hours'
 const WEATHER_SHOW_FIVEDAY_FORECAST_KEY = 'showFivedayForecast'
@@ -85,6 +86,7 @@ const KEYS = [
   WEATHER_CITY_KEY,
   WEATHER_WOEID_KEY,
   WEATHER_TRANSLATE_CONDITION_KEY,
+  WEATHER_VERTICAL_ORIENTATION_KEY,
   WEATHER_SHOW_TEXT_IN_PANEL_KEY,
   WEATHER_SHOW_COMMENT_IN_PANEL_KEY,
   WEATHER_SHOW_SUNRISE_KEY,
@@ -747,7 +749,7 @@ MyApplet.prototype = {
     this.destroyFutureWeather()
 
     this._forecast = []
-    this._forecastBox = new St.BoxLayout()
+    this._forecastBox = new St.BoxLayout({ vertical: this._verticalOrientation })
     this._futureWeather.set_child(this._forecastBox)
 
     let daysToShow = this._showFivedayForecast ? 5 : 2

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -46,6 +46,11 @@
     , "kPa": "kPa"
     }
   }
+, "verticalOrientation":
+  { "type": "checkbox"
+  , "default": false
+  , "description": "Vertical orientation"
+  }
 , "showSunrise":
   { "type": "checkbox"
   , "default": true


### PR DESCRIPTION
This pull request adds a new "vertical orientation" setting (default is false) to allow the display of future weather forecasts to be oriented vertically instead of horizontally.  This enhancement enables the user to optimize the applet footprint for his or her particular screen.
