### PR TITLE
Fix applet.js to generate up to date .pot file

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -551,9 +551,9 @@ MyApplet.prototype = {
         this._currentWeatherLocation.url = weather.get_string_member('link')
         this._currentWeatherLocation.label = _(location)
 
-        // gettext can't see these inline
-        let sunriseText = _('Sunrise')
-        let sunsetText = _('Sunset')
+
+        let sunriseText = _("Sunrise")
+        let sunsetText = _("Sunset")
 
         let astronomyJson = weather.get_object_member('astronomy')
         let sunriseTime = this.formatAstronomyTime(astronomyJson, 'sunrise')
@@ -645,8 +645,8 @@ MyApplet.prototype = {
 , showLoadingUi: function showLoadingUi() {
     this.destroyCurrentWeather()
     this.destroyFutureWeather()
-    this._currentWeather.set_child(new St.Label({ text: _('Loading current weather ...') }))
-    this._futureWeather.set_child(new St.Label({ text: _('Loading future weather ...') }))
+    this._currentWeather.set_child(new St.Label({ text: _("Loading current weather ...") }))
+    this._futureWeather.set_child(new St.Label({ text: _("Loading future weather ...") }))
   }
 
 , rebuild: function rebuild() {
@@ -668,13 +668,13 @@ MyApplet.prototype = {
 
     // The summary of the current weather
     this._currentWeatherSummary = new St.Label({
-      text: _('Loading ...'),
+      text: _("Loading ..."),
       style_class: STYLE_SUMMARY
     })
 
     this._currentWeatherLocation = new St.Button({
       reactive: true,
-      label: _('Refresh')
+      label: _("Refresh")
     })
 
     this._currentWeatherLocation.style_class = STYLE_LOCATION_LINK
@@ -737,15 +737,15 @@ MyApplet.prototype = {
     rb.add_actor(rb_captions)
     rb.add_actor(rb_values)
 
-    rb_captions.add_actor(new St.Label({text: _('Temperature:')}))
+    rb_captions.add_actor(new St.Label({text: _("Temperature:")}))
     rb_values.add_actor(this._currentWeatherTemperature)
-    rb_captions.add_actor(new St.Label({text: _('Humidity:')}))
+    rb_captions.add_actor(new St.Label({text: _("Humidity:")}))
     rb_values.add_actor(this._currentWeatherHumidity)
-    rb_captions.add_actor(new St.Label({text: _('Pressure:')}))
+    rb_captions.add_actor(new St.Label({text: _("Pressure:")}))
     rb_values.add_actor(this._currentWeatherPressure)
-    rb_captions.add_actor(new St.Label({text: _('Wind:')}))
+    rb_captions.add_actor(new St.Label({text: _("Wind:")}))
     rb_values.add_actor(this._currentWeatherWind)
-    rb_captions.add_actor(new St.Label({text: _('Wind Chill:')}))
+    rb_captions.add_actor(new St.Label({text: _("Wind Chill:")}))
     rb_values.add_actor(this._currentWeatherWindChill)
 
     let xb = new St.BoxLayout()
@@ -950,110 +950,110 @@ MyApplet.prototype = {
 , weatherCondition: function(code) {
     switch (parseInt(code, 10)){
       case 0:/* tornado */
-        return _('Tornado')
+        return _("Tornado")
       case 1:/* tropical storm */
-        return _('Tropical storm')
+        return _("Tropical storm")
       case 2:/* hurricane */
-        return _('Hurricane')
+        return _("Hurricane")
       case 3:/* severe thunderstorms */
-        return _('Severe thunderstorms')
+        return _("Severe thunderstorms")
       case 4:/* thunderstorms */
-        return _('Thunderstorms')
+        return _("Thunderstorms")
       case 5:/* mixed rain and snow */
-        return _('Mixed rain and snow')
+        return _("Mixed rain and snow")
       case 6:/* mixed rain and sleet */
-        return _('Mixed rain and sleet')
+        return _("Mixed rain and sleet")
       case 7:/* mixed snow and sleet */
-        return _('Mixed snow and sleet')
+        return _("Mixed snow and sleet")
       case 8:/* freezing drizzle */
-        return _('Freezing drizzle')
+        return _("Freezing drizzle")
       case 9:/* drizzle */
-        return _('Drizzle')
+        return _("Drizzle")
       case 10:/* freezing rain */
-        return _('Freezing rain')
+        return _("Freezing rain")
       case 11:/* showers */
-        return _('Showers')
+        return _("Showers")
       case 12:/* showers */
-        return _('Showers')
+        return _("Showers")
       case 13:/* snow flurries */
-        return _('Snow flurries')
+        return _("Snow flurries")
       case 14:/* light snow showers */
-        return _('Light snow showers')
+        return _("Light snow showers")
       case 15:/* blowing snow */
-        return _('Blowing snow')
+        return _("Blowing snow")
       case 16:/* snow */
-        return _('Snow')
+        return _("Snow")
       case 17:/* hail */
-        return _('Hail')
+        return _("Hail")
       case 18:/* sleet */
-        return _('Sleet')
+        return _("Sleet")
       case 19:/* dust */
-        return _('Dust')
+        return _("Dust")
       case 20:/* foggy */
-        return _('Foggy')
+        return _("Foggy")
       case 21:/* haze */
-        return _('Haze')
+        return _("Haze")
       case 22:/* smoky */
-        return _('Smoky')
+        return _("Smoky")
       case 23:/* blustery */
-        return _('Blustery')
+        return _("Blustery")
       case 24:/* windy */
-        return _('Windy')
+        return _("Windy")
       case 25:/* cold */
-        return _('Cold')
+        return _("Cold")
       case 26:/* cloudy */
-        return _('Cloudy')
+        return _("Cloudy")
       case 27:/* mostly cloudy (night) */
       case 28:/* mostly cloudy (day) */
-        return _('Mostly cloudy')
+        return _("Mostly cloudy")
       case 29:/* partly cloudy (night) */
       case 30:/* partly cloudy (day) */
-        return _('Partly cloudy')
+        return _("Partly cloudy")
       case 31:/* clear (night) */
-        return _('Clear')
+        return _("Clear")
       case 32:/* sunny */
-        return _('Sunny')
+        return _("Sunny")
       case 33:/* fair (night) */
       case 34:/* fair (day) */
-        return _('Fair')
+        return _("Fair")
       case 35:/* mixed rain and hail */
-        return _('Mixed rain and hail')
+        return _("Mixed rain and hail")
       case 36:/* hot */
-        return _('Hot')
+        return _("Hot")
       case 37:/* isolated thunderstorms */
-        return _('Isolated thunderstorms')
+        return _("Isolated thunderstorms")
       case 38:/* scattered thunderstorms */
       case 39:/* scattered thunderstorms */
-        return _('Scattered thunderstorms')
+        return _("Scattered thunderstorms")
       case 40:/* scattered showers */
-        return _('Scattered showers')
+        return _("Scattered showers")
       case 41:/* heavy snow */
-        return _('Heavy snow')
+        return _("Heavy snow")
       case 42:/* scattered snow showers */
-        return _('Scattered snow showers')
+        return _("Scattered snow showers")
       case 43:/* heavy snow */
-        return _('Heavy snow')
+        return _("Heavy snow")
       case 44:/* partly cloudy */
-        return _('Partly cloudy')
+        return _("Partly cloudy")
       case 45:/* thundershowers */
-        return _('Thundershowers')
+        return _("Thundershowers")
       case 46:/* snow showers */
-        return _('Snow showers')
+        return _("Snow showers")
       case 47:/* isolated thundershowers */
-        return _('Isolated thundershowers')
+        return _("Isolated thundershowers")
       case 3200:/* not available */
       default:
-        return _('Not available')
+        return _("Not available")
     }
   }
 
 , localeDay: function(abr) {
-    let days = [_('Monday'), _('Tuesday'), _('Wednesday'), _('Thursday'), _('Friday'), _('Saturday'), _('Sunday')]
+    let days = [_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")]
     return days[this.parseDay(abr)]
   }
 
 , compassDirection: function(deg) {
-    let directions = [_('N'), _('NE'), _('E'), _('SE'), _('S'), _('SW'), _('W'), _('NW')]
+    let directions = [_("N"), _("NE"), _("E"), _("SE"), _("S"), _("SW"), _("W"), _("NW")]
     return directions[Math.round(deg / 45) % directions.length]
   }
 

--- a/po/weather@mockturtl.pot
+++ b/po/weather@mockturtl.pot
@@ -2,13 +2,13 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"POT-Creation-Date: 2016-08-27 10:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -301,8 +301,20 @@ msgstr ""
 msgid "NW"
 msgstr ""
 
+#. cinnamon-weather->metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. cinnamon-weather->metadata.json->name
+msgid "Weather"
+msgstr ""
+
 #. cinnamon-weather->settings-schema.json->woeidLookup->description
 msgid "Get WOEID"
+msgstr ""
+
+#. cinnamon-weather->settings-schema.json->woeidLookup->tooltip
+msgid "http://woeid.rosselliot.co.nz/"
 msgstr ""
 
 #. cinnamon-weather->settings-schema.json->verticalOrientation->description
@@ -427,12 +439,4 @@ msgstr ""
 
 #. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
 msgid "Symbolic icons"
-msgstr ""
-
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
-msgstr ""
-
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
 msgstr ""


### PR DESCRIPTION
Hello, 

This is a pull request for a problem with pot file generation. 

Without this pull request, if you update the pot file using this command: 
`cinnamon-json-makepot --js po/weather@mockturtl.pot`

You will see that the pot does not contain some strings anymore. 

This is because cinnamon-json-makepot does not take into account string identifier between single quotes (e.g. `_('Sunrise')`) but only those between double quotes (e.g. `_("Sunrise")`);

I have updated applet.js to use double quotes when needed, and I have also updated the pot file to match the latest changes. 

Can you have a look at this PR ?

Thanks.
